### PR TITLE
Use metadata-filter from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest": "^26.4.0",
     "lodash": "^4.17.19",
     "luxon": "^1.24.1",
-    "metadata-filter": "github:web-scrobbler/metadata-filter#master",
+    "metadata-filter": "v1.0.0",
     "next": "^9.5.1",
     "patch-package": "^6.2.2",
     "pg": "^8.3.0",


### PR DESCRIPTION
I released metadata-filter v1.0.0 recently, so now it's safer to use install it from npm. :)